### PR TITLE
Cambio de la url base

### DIFF
--- a/BioService/App.config
+++ b/BioService/App.config
@@ -11,7 +11,7 @@
     <userSettings>
         <BioService.Properties.Settings>
             <setting name="ConectionURL" serializeAs="String">
-                <value>http://34.95.241.213/api/</value>
+                <value>http://194.62.96.218/api/</value>
             </setting>
         </BioService.Properties.Settings>
     </userSettings>

--- a/BioService/Properties/Settings.Designer.cs
+++ b/BioService/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace BioService.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.8.1.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -25,7 +25,7 @@ namespace BioService.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("http://34.95.241.213/api/")]
+        [global::System.Configuration.DefaultSettingValueAttribute("http://194.62.96.218/api/")]
         public string ConectionURL {
             get {
                 return ((string)(this["ConectionURL"]));

--- a/BioService/Properties/Settings.settings
+++ b/BioService/Properties/Settings.settings
@@ -3,7 +3,7 @@
   <Profiles />
   <Settings>
     <Setting Name="ConectionURL" Type="System.String" Scope="User">
-      <Value Profile="(Default)">http://34.95.241.213/api/</Value>
+      <Value Profile="(Default)">http://194.62.96.218/api/</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/BioService/ServicioBiometricoGKD.cs
+++ b/BioService/ServicioBiometricoGKD.cs
@@ -23,7 +23,7 @@ namespace WindowsBiometricaService
         Timer timer3;
         Boolean Conectado;
         int idMaquina;
-        private String direccion = "http://34.95.241.213/api/";
+        private readonly string direccion = BioService.Properties.Settings.Default.ConectionURL;
         List<Dispositivo> listaDispositivos = new List<Dispositivo>();
         List<Usuario> listaUsuarios = new List<Usuario>();
         List<Usuario> listaUsuariosStaff = new List<Usuario>();


### PR DESCRIPTION
se cambió la url base de conexión para las consultas y se modificó el codigo principal donde se utiliza la ruta para que la tome desde el archivo de configuración